### PR TITLE
Converted functions like `to_` to be `into_`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The `toArray()` method takes a callback that is called once, either on first err
 zstreams(fs.createReadStream('./test.txt')).throughSync(function(chunk) {
 	return chunk.toString('utf8').toUpperCase();
 }).pipe(fs.createWriteStream('./uppercase.txt'));
-// Instead of .pipe(...) you can also do .toFile('./uppercase.txt')
+// Instead of .pipe(...) you can also do .intoFile('./uppercase.txt')
 ````
 
 A set of `through` methods are available on readables to easily transform data.  They create a Transform stream, use the supplied
@@ -147,7 +147,7 @@ stream.firstError(function(error) {
 
 // This similar function is only available on Writable streams.  The given callback is called either on error or when the
 // Writable emits `finish`.  In either case, it is guaranteed to be only called once.
-writable.toCallback(function(error) {
+writable.intoCallback(function(error) {
 
 });
 ````

--- a/lib/mixins/_readable.js
+++ b/lib/mixins/_readable.js
@@ -167,9 +167,9 @@ _Readable.prototype.filterSync = function(filterFunc) {
 	});
 };
 
-_Readable.prototype.toArray = function(cb) {
+_Readable.prototype.intoArray = function(cb) {
 	var arrayWritableStream = new ArrayWritableStream({ objectMode: this.isReadableObjectMode() });
-	this.pipe(arrayWritableStream).toCallback(function(error) {
+	this.pipe(arrayWritableStream).intoCallback(function(error) {
 		if(error) {
 			cb(error);
 		} else {
@@ -178,13 +178,13 @@ _Readable.prototype.toArray = function(cb) {
 	});
 };
 
-_Readable.prototype.toFile = function(path, options) {
+_Readable.prototype.intoFile = function(path, options) {
 	return this.pipe(fs.createWriteStream(path, options));
 };
 
 _Readable.prototype.intoString = function(cb) {
 	var stringWritableStream = new StringWritableStream({ objectMode: this.isReadableObjectMode() });
-	this.pipe(stringWritableStream).toCallback(function(error) {
+	this.pipe(stringWritableStream).intoCallback(function(error) {
 		if(error) {
 			cb(error);
 		} else {

--- a/lib/mixins/_writable.js
+++ b/lib/mixins/_writable.js
@@ -1,4 +1,3 @@
-
 /**
  * Writable mixins for ZWritable streams.
  *
@@ -36,7 +35,7 @@ _Writable.prototype.firstFinish = function(handler) {
 	return this.once('finish', handler);
 };
 
-_Writable.prototype.toCallback = function(cb) {
+_Writable.prototype.intoCallback = function(cb) {
 	var calledCb = false;
 	this.firstError(function(error) {
 		if(calledCb) return;

--- a/test/array-readable-stream-test.js
+++ b/test/array-readable-stream-test.js
@@ -4,7 +4,7 @@ var ArrayReadableStream = require('../lib').ArrayReadableStream;
 describe('ArrayReadableStream', function() {
 	it('should transform an array to an equivalent array', function(done) {
 		var arr = [1, 2, 3, 4, 5, 6];
-		new ArrayReadableStream(arr).toArray(function(err, result) {
+		new ArrayReadableStream(arr).intoArray(function(err, result) {
 			if(err) { throw err; }
 			expect(result).to.be.instanceof(Array);
 			expect(result).to.have.length(arr.length);

--- a/test/batch-stream-test.js
+++ b/test/batch-stream-test.js
@@ -9,7 +9,7 @@ describe('BatchStream', function() {
 		var arrStream = new ArrayReadableStream([0, 1, 2, 3, 4, 5, 6, 7]);
 		var bs = new BatchStream(3, {});
 
-		arrStream.pipe(bs).toArray(function(error, arrays) {
+		arrStream.pipe(bs).intoArray(function(error, arrays) {
 			expect(error).to.not.exist;
 			expect(arrays).to.be.instanceof(Array);
 			expect(arrays).to.have.length(3);
@@ -40,7 +40,7 @@ describe('BatchStream', function() {
 		var arrStream = new ArrayReadableStream(arr);
 		var bs = new BatchStream();
 
-		arrStream.pipe(bs).toArray(function(error, arrays) {
+		arrStream.pipe(bs).intoArray(function(error, arrays) {
 			expect(error).to.not.exist;
 			expect(arrays).to.be.instanceof(Array);
 			expect(arrays).to.have.length(4);
@@ -50,7 +50,7 @@ describe('BatchStream', function() {
 	});
 
 	it('should not push empty batches', function(done) {
-		zstreams.fromArray(['a', 'b', 'c', 'd']).pipe(new BatchStream(1)).toArray(function(error, arrays) {
+		zstreams.fromArray(['a', 'b', 'c', 'd']).pipe(new BatchStream(1)).intoArray(function(error, arrays) {
 			expect(error).to.not.exist;
 			expect(arrays).to.be.instanceof(Array);
 			expect(arrays).to.have.length(4);

--- a/test/filter-stream-test.js
+++ b/test/filter-stream-test.js
@@ -11,7 +11,7 @@ describe('FilterStream', function() {
 			cb(null, (entry % 2 === 0));
 		});
 
-		arrStream.pipe(fs).toArray(function(error, array) {
+		arrStream.pipe(fs).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array.length).to.equal(4);

--- a/test/from-test.js
+++ b/test/from-test.js
@@ -5,8 +5,8 @@ var zstreams = require('../lib');
 describe('zstreams.fromArray', function() {
 	it('should create an object stream from an array', function(done) {
 		var input = ['a', 'b', 'c', 'd'];
-		var arrayStream = zstreams.fromArray(input)
-		arrayStream.toArray(function(error, array) {
+		var arrayStream = zstreams.fromArray(input);
+		arrayStream.intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(arrayStream.isReadableObjectMode()).to.equal(true);
 			expect(array).to.be.instanceof(Array);
@@ -42,7 +42,7 @@ describe('zstreams.fromFunction', function() {
 				ret = 'a';
 			}
 			cb(null, ret);
-		}).toArray(function(error, array) {
+		}).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array).to.have.length(4);
@@ -54,7 +54,7 @@ describe('zstreams.fromFunction', function() {
 	it('should handle errors', function(done) {
 		zstreams.fromFunction(function(cb) {
 			cb(new Error('Erroring out'));
-		}).toArray(function(error) {
+		}).intoArray(function(error) {
 			expect(error).to.exist;
 			done();
 		});
@@ -70,7 +70,7 @@ describe('zstreams.fromFunctionSync', function() {
 				ret = 'a';
 			}
 			return ret;
-		}).toArray(function(error, array) {
+		}).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array).to.have.length(4);
@@ -80,9 +80,9 @@ describe('zstreams.fromFunctionSync', function() {
 	});
 
 	it('should handle errors', function(done) {
-		zstreams.fromFunctionSync(function(cb) {
+		zstreams.fromFunctionSync(function() {
 			throw new Error('Erroring out');
-		}).toArray(function(error) {
+		}).intoArray(function(error) {
 			expect(error).to.exist;
 			done();
 		});

--- a/test/function-stream-test.js
+++ b/test/function-stream-test.js
@@ -12,7 +12,7 @@ describe('FunctionStream', function() {
 				ret = 'a';
 			}
 			cb(null, ret);
-		}).toArray(function(error, array) {
+		}).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array).to.have.length(4);
@@ -24,7 +24,7 @@ describe('FunctionStream', function() {
 	it('should handle errors', function(done) {
 		new FunctionStream(function(cb) {
 			cb(new Error('Erroring out'));
-		}).toArray(function(error) {
+		}).intoArray(function(error) {
 			expect(error).to.exist;
 			done();
 		});

--- a/test/intersperse-stream-test.js
+++ b/test/intersperse-stream-test.js
@@ -33,7 +33,7 @@ describe('IntersperseStream', function() {
 			this.push(null);
 		};
 		var is = new IntersperseStream(' ', { objectMode: true });
-		readStream.pipe(is).toArray(function(error, array) {
+		readStream.pipe(is).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array.length).to.equal(7);
@@ -58,7 +58,7 @@ describe('IntersperseStream', function() {
 			this.push(null);
 		};
 		var is = new IntersperseStream({ objectMode: true });
-		readStream.pipe(is).toArray(function(error, array) {
+		readStream.pipe(is).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array.length).to.equal(7);
@@ -80,7 +80,7 @@ describe('IntersperseStream', function() {
 			this.push(null);
 		};
 		var is = new IntersperseStream({ objectMode: true });
-		readStream.pipe(is).toArray(function(error, array) {
+		readStream.pipe(is).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array.length).to.equal(1);

--- a/test/pluck-stream-test.js
+++ b/test/pluck-stream-test.js
@@ -17,7 +17,7 @@ describe('PluckStream', function() {
 			this.push(null);
 		};
 		var ps = new PluckStream('a');
-		readStream.pipe(ps).toArray(function(error, array) {
+		readStream.pipe(ps).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array.length).to.equal(4);
@@ -42,7 +42,7 @@ describe('PluckStream', function() {
 			this.push(null);
 		};
 		var ps = new PluckStream();
-		readStream.pipe(ps).toArray(function(error, array) {
+		readStream.pipe(ps).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array.length).to.equal(2);

--- a/test/split-stream-test.js
+++ b/test/split-stream-test.js
@@ -13,7 +13,7 @@ describe('SplitStream', function() {
 			this.push(null);
 		};
 		var ss = new SplitStream(' ');
-		readStream.pipe(ss).toArray(function(error, array) {
+		readStream.pipe(ss).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array.length).to.equal(8);
@@ -34,7 +34,7 @@ describe('SplitStream', function() {
 			this.push(null);
 		};
 		var ss = new SplitStream();
-		readStream.pipe(ss).toArray(function(error, array) {
+		readStream.pipe(ss).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array.length).to.equal(4);
@@ -55,7 +55,7 @@ describe('SplitStream', function() {
 			this.push(' Test');
 			this.push(null);
 		};
-		readStream.pipe(new SplitStream(/ +/)).toArray(function(error, array) {
+		readStream.pipe(new SplitStream(/ +/)).intoArray(function(error, array) {
 			expect(error).to.not.exist;
 			expect(array).to.be.instanceof(Array);
 			expect(array).to.have.length(2);

--- a/test/string-writable-stream-test.js
+++ b/test/string-writable-stream-test.js
@@ -15,7 +15,7 @@ describe('StringWritableStream', function() {
 			this.push(null);
 		};
 		var sws = new StringWritableStream({ objectMode: false });
-		readStream.pipe(sws).toCallback(function(error) {
+		readStream.pipe(sws).intoCallback(function(error) {
 			expect(error).to.not.exist;
 
 			var str = sws.getString();
@@ -35,7 +35,7 @@ describe('StringWritableStream', function() {
 			this.push(null);
 		};
 		var sws = new StringWritableStream({ objectMode: true });
-		readStream.pipe(sws).toCallback(function(error) {
+		readStream.pipe(sws).intoCallback(function(error) {
 			expect(error).to.not.exist;
 
 			var str = sws.getString();


### PR DESCRIPTION
The former way of doing this odesn't support all needed operations (namely, `toString`)

Fixes #12 