### PR TITLE
Cleanup and document classic streams

### DIFF
--- a/lib/duplex.js
+++ b/lib/duplex.js
@@ -5,6 +5,18 @@ var streamMixins = require('./mixins/_stream');
 var readableMixins = require('./mixins/_readable');
 var writableMixins = require('./mixins/_writable');
 
+/**
+ * ZDuplex implements the Duplex stream interface.
+ * ZDuplex also allows for a `_flush` function to facilitate cleanup.
+ *
+ * @class ZDuplex
+ * @constructor
+ * @extends Duplex
+ * @uses _Stream
+ * @uses _Readable
+ * @uses _Writable
+ * @param {Object} [options] - Stream options
+ */
 function ZDuplex(options) {
 	if(options) {
 		if(options.objectMode) {

--- a/lib/mixins/_classic.js
+++ b/lib/mixins/_classic.js
@@ -1,0 +1,24 @@
+/**
+ * Classic mixins for wrapped "classic" streams.
+ *
+ * This class cannot be instantiated in itself.  Its prototype methods must be added to the prototype
+ * of the class it's being mixed into, and its constructor must be called from the superclass's constructor.
+ *
+ * @class _Classic
+ * @constructor
+ */
+function _Classic(stream) {
+	this._isClassicZStream = true;
+	this._internalStream = stream;
+}
+module.exports = _Classic;
+
+_Classic.prototype.getInternalStream = function() {
+	return this._internalStream;
+};
+
+_Classic.prototype._abortStream = function() {
+	if(typeof this._internalStream.destroy === 'function') {
+		this._internalStream.destroy();
+	}
+};

--- a/lib/passthrough.js
+++ b/lib/passthrough.js
@@ -5,6 +5,17 @@ var streamMixins = require('./mixins/_stream');
 var readableMixins = require('./mixins/_readable');
 var writableMixins = require('./mixins/_writable');
 
+/**
+ * ZPassThrough writes everything written to it into the other side
+ *
+ * @class ZPassThrough
+ * @constructor
+ * @extends PassThrough
+ * @uses _Stream
+ * @uses _Readable
+ * @uses _Writable
+ * @param {Object} [options] - Stream options
+ */
 function ZPassThrough(options) {
 	if(options) {
 		if(options.objectMode) {

--- a/lib/readable.js
+++ b/lib/readable.js
@@ -4,6 +4,16 @@ var extend = require('extend');
 var streamMixins = require('./mixins/_stream');
 var readableMixins = require('./mixins/_readable');
 
+/**
+ * ZReadable implements the Readable streams interface
+ *
+ * @class ZReadable
+ * @constructor
+ * @extends Readable
+ * @uses _Stream
+ * @uses _Readable
+ * @param {Object} [options] - Stream options
+ */
 function ZReadable(options) {
 	if(options && options.readableObjectMode) {
 		options.objectMode = true;
@@ -17,5 +27,3 @@ module.exports = ZReadable;
 
 extend(ZReadable.prototype, streamMixins.prototype);
 extend(ZReadable.prototype, readableMixins.prototype);
-
-

--- a/lib/streams/classic-duplex.js
+++ b/lib/streams/classic-duplex.js
@@ -3,18 +3,30 @@ var PassThrough = require('../passthrough');
 var ClassicWritable = require('./classic-writable');
 var ClassicReadable = require('./classic-readable');
 var inherits = require('util').inherits;
+var extend = require('extend');
+var classicMixins = require('../mixins/_classic');
 
+/**
+ * ClassicDuplex wraps a "classic" duplex stream.
+ *
+ * @class ClassicDuplex
+ * @constructor
+ * @extends CompoundDuplex
+ * @uses _Classic
+ * @param {Stream} stream - The classic stream being wrapped
+ * @param {Object} [options] - Stream options
+ */
 function ClassicDuplex(stream, options) {
 	var readable, writable, classicReadable, classicWritable, self = this;
 
 	readable = new PassThrough();
 	writable = new PassThrough();
 	CompoundDuplex.call(self, writable, readable, options);
-	self._internalStream = stream;
+	classicMixins.call(this, stream, options);
 
 	classicReadable = this._internalReadable = new ClassicReadable(stream, options);
 	classicReadable.on('error', this._duplexHandleInternalError.bind(this));
-	
+
 	classicWritable = this._internalWritable = new ClassicWritable(stream, options);
 	classicWritable.on('error', this._duplexHandleInternalError.bind(this));
 
@@ -22,10 +34,6 @@ function ClassicDuplex(stream, options) {
 	classicReadable.pipe(readable);
 }
 inherits(ClassicDuplex, CompoundDuplex);
-
-ClassicDuplex.prototype.getInternalStream = function() {
-	return this._internalStream;
-};
 
 ClassicDuplex.prototype._duplexHandleInternalError = function(error) {
 	if(error === this._lastError) {
@@ -37,10 +45,6 @@ ClassicDuplex.prototype._duplexHandleInternalError = function(error) {
 	this.emit('error', error);
 };
 
-ClassicDuplex.prototype._abortStream = function() {
-	if(this._internalStream.destroy) {
-		this._internalStream.destroy();
-	}
-};
-
 module.exports = exports = ClassicDuplex;
+
+extend(ClassicDuplex.prototype, classicMixins.prototype);

--- a/lib/streams/classic-readable.js
+++ b/lib/streams/classic-readable.js
@@ -1,17 +1,27 @@
 var Readable = require('../readable');
 var inherits = require('util').inherits;
+var extend = require('extend');
+var classicMixins = require('../mixins/_classic');
 
+/**
+ * ClassicReadable wraps a "classic" readable stream.
+ *
+ * @class ClassicReadable
+ * @constructor
+ * @extends Readable
+ * @uses _Classic
+ * @param {Stream} stream - The classic stream being wrapped
+ * @param {Object} [options] - Stream options
+ */
 function ClassicReadable(stream, options) {
 	Readable.call(this, options);
-	this._internalStream = stream;
+	classicMixins.call(this, stream, options);
 
 	// Readable streams already include a wrapping for Classic Streams
 	this.wrap(stream);
 }
 inherits(ClassicReadable, Readable);
 
-ClassicReadable.prototype.getInternalStream = function() {
-	return this._internalStream;
-};
-
 module.exports = ClassicReadable;
+
+extend(ClassicReadable.prototype, classicMixins.prototype);

--- a/lib/streams/classic-readable.js
+++ b/lib/streams/classic-readable.js
@@ -8,7 +8,7 @@ var classicMixins = require('../mixins/_classic');
  *
  * @class ClassicReadable
  * @constructor
- * @extends Readable
+ * @extends ZReadable
  * @uses _Classic
  * @param {Stream} stream - The classic stream being wrapped
  * @param {Object} [options] - Stream options

--- a/lib/streams/classic-writable.js
+++ b/lib/streams/classic-writable.js
@@ -8,7 +8,7 @@ var classicMixins = require('../mixins/_classic');
  *
  * @class ClassicWritable
  * @constructor
- * @extends Writable
+ * @extends ZWritable
  * @uses _Classic
  * @param {Stream} stream - The classic stream being wrapped
  * @param {Object} [options] - Stream options

--- a/lib/streams/classic-writable.js
+++ b/lib/streams/classic-writable.js
@@ -1,11 +1,23 @@
 var Writable = require('../writable');
 var inherits = require('util').inherits;
+var extend = require('extend');
+var classicMixins = require('../mixins/_classic');
 
+/**
+ * ClassicWritable wraps a "classic" writable stream.
+ *
+ * @class ClassicWritable
+ * @constructor
+ * @extends Writable
+ * @uses _Classic
+ * @param {Stream} stream - The classic stream being wrapped
+ * @param {Object} [options] - Stream options
+ */
 function ClassicWritable(stream, options) {
 	var self = this;
 
 	Writable.call(this, options);
-	self._internalStream = stream;
+	classicMixins.call(this, stream, options);
 
 	stream.on('error', function(error) {
 		self.emit('error', error);
@@ -19,10 +31,6 @@ function ClassicWritable(stream, options) {
 	self._writeQueue = [];
 }
 inherits(ClassicWritable, Writable);
-
-ClassicWritable.prototype.getInternalStream = function() {
-	return this._internalStream;
-};
 
 ClassicWritable.prototype._performWrites = function() {
 	if(this._isClosed) { return false; }
@@ -53,10 +61,6 @@ ClassicWritable.prototype._flush = function(cb) {
 	this._internalStream.end();
 };
 
-ClassicWritable.prototype._abortStream = function() {
-	if(this._internalStream.destroy) {
-		this._internalStream.destroy();
-	}
-};
-
 module.exports = ClassicWritable;
+
+extend(ClassicWritable.prototype, classicMixins.prototype);

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -5,6 +5,17 @@ var streamMixins = require('./mixins/_stream');
 var readableMixins = require('./mixins/_readable');
 var writableMixins = require('./mixins/_writable');
 
+/**
+ * ZTransform transforms input to the stream through the _transform function.
+ *
+ * @class ZTransform
+ * @constructor
+ * @extends Transform
+ * @uses _Stream
+ * @uses _Readable
+ * @uses _Writable
+ * @param {Object} [options] - Stream options
+ */
 function ZTransform(options) {
 	if(options) {
 		if(options.objectMode) {
@@ -37,4 +48,3 @@ module.exports = ZTransform;
 extend(ZTransform.prototype, streamMixins.prototype);
 extend(ZTransform.prototype, readableMixins.prototype);
 extend(ZTransform.prototype, writableMixins.prototype);
-

--- a/lib/writable.js
+++ b/lib/writable.js
@@ -4,6 +4,17 @@ var extend = require('extend');
 var streamMixins = require('./mixins/_stream');
 var writableMixins = require('./mixins/_writable');
 
+/**
+ * ZWritable implements the Writable stream interface with the _write function.
+ * ZWritable also accepts a `_flush` function to facilitate cleanup.
+ *
+ * @class ZWritable
+ * @constructor
+ * @extends Transform
+ * @uses _Stream
+ * @uses _Writable
+ * @param {Object} [options] - Stream options
+ */
 function ZWritable(options) {
 	if(options && options.writableObjectMode) {
 		options.objectMode = true;
@@ -23,4 +34,3 @@ extend(ZWritable.prototype, writableMixins.prototype);
 ZWritable.prototype._read = function() {
 	this.push(null);
 };
-


### PR DESCRIPTION
Moved common "classic" functions into a mixin and added documentation for base classes.